### PR TITLE
ToolheadScanner: update 3 toolhead(s) — Apogee, MiniBurner XL, MiniSB-Extruder

### DIFF
--- a/src/data/toolheads.json
+++ b/src/data/toolheads.json
@@ -204,8 +204,14 @@
         "CRTouch"
       ],
       "boards": "unknown",
-      "hotend_fan": "3010",
-      "part_cooling_fan": "4010",
+      "hotend_fan": [
+        "3010",
+        "4010"
+      ],
+      "part_cooling_fan": [
+        "4010",
+        "3010"
+      ],
       "filament_cutter": "unknown",
       "printer_compatibility": [
         "Switchwire",
@@ -978,7 +984,10 @@
       ],
       "probe": "Klicky",
       "boards": "unknown",
-      "hotend_fan": "2510",
+      "hotend_fan": [
+        "2510",
+        "5015"
+      ],
       "part_cooling_fan": "5015",
       "filament_cutter": "native",
       "printer_compatibility": [
@@ -1017,7 +1026,10 @@
         "Klicky",
         "Boop"
       ],
-      "boards": "Picobilical",
+      "boards": [
+        "Picobilical",
+        "Toolhead PCB"
+      ],
       "hotend_fan": "3007",
       "part_cooling_fan": "3010",
       "filament_cutter": "unknown",


### PR DESCRIPTION
Automated scan update from ToolheadScanner.

Updated toolhead(s): Apogee, MiniBurner XL, MiniSB-Extruder

### Apogee
- **hotend_fan::4010**: we have a 4010 fan and dragon hotend. Because radial fans actually do not have airflow
- **part_cooling_fan::3010**: Second, the hotend cooling fan. This design uses a small 3010 radial

### MiniBurner XL
- **hotend_fan::5015**: Its build for hotends with volcano lenght nozzle, has a 2510 hotend cooling fan, and dual 5015 "rehoused" part cooling fans.

### MiniSB-Extruder
- **Toolhead PCB**: Also included are Strain-Reliefs (quickly and crappily thrown together), Mounting Plates for the [Umbilical-PCB by Timmit](https://github.com/VoronDesign/Voron-Hardware/tree/master/V0-Umbilical) and mounting plates for CAN Toolhead boards based on [@KayosMaker/CANboard_Mounts](https://github.com/KayosMaker/CANboard_Mounts). The Umbilical Plates also support the LDO Picobilical. **If you use a PCB Toolhead board please double-check, that the screws on the mounting plate don't short anything!**
