### PR TITLE
ToolheadScanner: update 1 toolhead(s) — Apogee

### DIFF
--- a/src/data/toolheads.json
+++ b/src/data/toolheads.json
@@ -205,8 +205,14 @@
         "CRTouch"
       ],
       "boards": "unknown",
-      "hotend_fan": "3010",
-      "part_cooling_fan": "4010",
+      "hotend_fan": [
+        "3010",
+        "4010"
+      ],
+      "part_cooling_fan": [
+        "4010",
+        "3010"
+      ],
       "filament_cutter": "unknown",
       "printer_compatibility": [
         "Switchwire",


### PR DESCRIPTION
Automated scan update from ToolheadScanner.

Updated toolhead(s): Apogee

### Apogee
- **hotend_fan::4010**: we have a 4010 fan and dragon hotend. Because radial fans actually do not have airflow
- **part_cooling_fan::3010**: Second, the hotend cooling fan. This design uses a small 3010 radial
