### PR TITLE
ToolheadScanner: update 1 toolhead(s) — A4T

### DIFF
--- a/src/data/toolheads.json
+++ b/src/data/toolheads.json
@@ -8,13 +8,15 @@
         "Orbiter 2",
         "Wristwatch G2",
         "Wristwatch BMG",
-        "Vz HextrudORT"
+        "Vz HextrudORT",
+        "Clockwork2"
       ],
       "probe": [
         "Tap",
         "Klicky",
         "Eddy",
-        "Omron"
+        "Omron",
+        "Cartographer"
       ],
       "hotend": [
         "Bambu X1/P1",
@@ -36,7 +38,10 @@
       "category": "Full Size Printers",
       "configurator": true,
       "hotend_fan": "2510",
-      "part_cooling_fan": "4010",
+      "part_cooling_fan": [
+        "4010",
+        "2510"
+      ],
       "filament_cutter": "native",
       "top_pick": true,
       "belt_path": [


### PR DESCRIPTION
Automated scan update from ToolheadScanner.

Updated toolhead(s): A4T

### A4T
- **Clockwork2**: | :information_source: **Clockwork2 carriage/Tap users**: Don't forget the 2x M3x8 SHCS that go behind the adapter      | <img src='docs/images/extruder_adapter_cw2.png' width=150> |
- **Cartographer**: A printer that fits either Xol carriage, or a standard voron CW2 or Tap carriage. `NOT cartographer CNC carriage (see warning below)`<br/>
- **part_cooling_fan::2510**: | Lock the 2510 HE fan in place by sliding the HE fan duct up until the flexture locks.<br/>`⚠️ Careful, don't pinch any wires`| <img src='docs/images/2510_install2.png' width=150> |
