### PR TITLE
ToolheadScanner: update 1 toolhead(s) — Burninator

### DIFF
--- a/src/data/toolheads.json
+++ b/src/data/toolheads.json
@@ -318,7 +318,8 @@
       "filament_cutter": "unsupported",
       "printer_compatibility": [
         "V2.4",
-        "Trident"
+        "Trident",
+        "V0"
       ],
       "belt_path": "Voron coreXY"
     },
@@ -1504,8 +1505,7 @@
       "category": "Printers for Ants",
       "image": "/SUSburner.webp",
       "configurator": true,
-      "extruders": [
-      ],
+      "extruders": [],
       "hotend": [
         "Rapido UHF",
         "Dragon UHF",


### PR DESCRIPTION
Automated scan update from ToolheadScanner.

Updated toolhead(s): Burninator

### Burninator
- **printer::V0**: This toolhead is yet another 4010 toolhead, heavily inspired by the [Dragonburner](https://github.com/chirpy2605/voron/tree/main/V0/Dragon_Burner) and the [A4T](https://github.com/Armchair-Heavy-Industries/A4T/tree/main), all props to them.
